### PR TITLE
Improve Overall Usage of Command Line Tool

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,8 +4,6 @@
 	"com.google.code.findbugs:jsr305": { "locked": "3.0.1" },
 	
 	"com.google.jimfs:jimfs": { "locked": "1.1" },
-	
-	"org.jline:jline": { "locked": "3.2.0" },
 
 	"org.bouncycastle:bcpg-jdk15on": { "locked": "1.56" },
 	

--- a/lockdown-cli/build.gradle
+++ b/lockdown-cli/build.gradle
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     compile project(':lockdown-core')
     compile group: 'args4j', name: 'args4j'
-    compile group: 'org.jline', name: 'jline'
     compile group: 'org.slf4j', name: 'slf4j-api'
     
     runtime group: 'org.slf4j', name: 'slf4j-simple'

--- a/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/AddCredentialsCommand.java
+++ b/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/AddCredentialsCommand.java
@@ -46,26 +46,20 @@ public class AddCredentialsCommand implements Runnable {
             usage = "Specifies the public key to use to encrypt credentials. Required")
     private File publicKey;
 
-    @Option(name = "-u", aliases = { "--username" }, required = false,
-            usage = "Specifies the username to store. Default is to enter at runtime")
-    private String username = null;
-
     @Override
     public void run() {
         try {
             CredentialStore store = CredentialStore.loadOrCreate(credentialStore.toPath());
             Console console = System.console();
 
-            if (username == null) {
-                username = console.readLine("Username: ");
-            }
-
+            String username = console.readLine("Username: ");
             char[] password = console.readPassword("Password: ");
-            char[] confirmPassword = console.readPassword("Confirm Password: ");
 
             if (password.length == 0) {
                 throw new IllegalArgumentException("Blank password entered");
             }
+
+            char[] confirmPassword = console.readPassword("Confirm Password: ");
 
             if (!Arrays.equals(password, confirmPassword)) {
                 throw new IllegalArgumentException("Passwords did not match");

--- a/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/KeyGeneratorCommand.java
+++ b/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/KeyGeneratorCommand.java
@@ -65,6 +65,8 @@ public class KeyGeneratorCommand implements Runnable {
 
         if (unremovableKeys.isEmpty()) {
             try {
+                Files.createDirectories(destinationDirectory);
+
                 KeyFiles generatedKeys = generator.createKeyPair(publicKeyDestination, privateKeyDestination);
 
                 logger.info("Key files generated to \n\tPublic: {}\n\tPrivate: {}",

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/CredentialStore.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/CredentialStore.java
@@ -105,6 +105,8 @@ public class CredentialStore {
         try (OutputStream outputStream = Files.newOutputStream(credentialFile)) {
             properties.store(outputStream, null);
         }
+
+        logger.info("Credentials added for lookup key {}", lookupKey);
     }
 
     /**
@@ -193,7 +195,7 @@ public class CredentialStore {
         if (!credentialFile.toFile().exists()) {
             boolean existed = credentialFile.toFile().createNewFile();
 
-            if (existed) {
+            if (!existed) {
                 logger.warn("File.exists() check did not match upon creation at location {}", credentialFile.toUri());
             }
         }


### PR DESCRIPTION
Through manual testing, several usage issues have been identified and addressed:
- Usage for sub-commands was not printing
- Usages was not printed if a user failed to enter a command
- Specifying an output directory that does not exist resulted in an exception
- Username/password entry was reading too fast, password could not be entered
- Blank passwords were accepted
- No feedback to user that blank password line had entered characters - ask user to confirm password
- Username entry is now via command, no longer allowed in arguments