### PR TITLE
GITHUB-17 Update license, headers, documentation, and distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Corona IDE
+Copyright 2017 The Corona-IDE@github.com Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Lockdown is intended for those cases - where the need for clear-text credentials
 
 Information for how to contribute to Lockdown can be found in [the contribution guidelines](CONTRIBUTING.md)
 
+## Legal
+
+Lockdown is distributed under the [MIT License](https://opensource.org/licenses/MIT). There are no requirements for using it in your own project (a line in a NOTICES file is appreciated but not necessary for use)
+
+The requirement for a copy of the license being included in distributions is fulfilled by a copy of the [LICENSE](./LICENSE) file being included in constructed JAR archives
+
 ## Projects
 
 ### lockdown-core

--- a/build.gradle
+++ b/build.gradle
@@ -79,15 +79,30 @@ allprojects{
 subprojects{
     apply plugin: 'maven-publish'
     
+    //Add LICENSE so it is included in all JARs, fulfilling the "distributions include license" requirement
+    jar{
+        from("${rootDir}"){
+            include 'LICENSE'
+        }
+    }
+    
     //All projects should provide source code and javadoc, and upload these with any released artifacts
     task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
         from sourceSets.main.allSource
+        
+        from("${rootDir}"){
+            include 'LICENSE'
+        }
     }
     
     task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
+        
+        from("${rootDir}"){
+            include 'LICENSE'
+        }
     }
     
     artifacts {

--- a/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/LockdownCommandLine.java
+++ b/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/LockdownCommandLine.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 28, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown.cli;
 

--- a/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/AddCredentialsCommand.java
+++ b/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/AddCredentialsCommand.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) May 2, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    "romeara" - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown.cli.command;
 
@@ -89,7 +85,7 @@ public class AddCredentialsCommand implements Runnable {
      * <p>
      * Tries to use System.console(), as is provides a more secure password entry mechanism. Falls back to Scanner if
      * the console is unavailable
-     * 
+     *
      * @author romeara
      * @since 0.1.0
      */

--- a/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/KeyGeneratorCommand.java
+++ b/lockdown-cli/src/main/java/com/coronaide/lockdown/cli/command/KeyGeneratorCommand.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 28, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown.cli.command;
 

--- a/lockdown-cli/src/test/java/com/coronaide/test/lockdown/cli/AddCredentialsTest.java
+++ b/lockdown-cli/src/test/java/com/coronaide/test/lockdown/cli/AddCredentialsTest.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) May 10, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    "romeara" - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.test.lockdown.cli;
 

--- a/lockdown-cli/src/test/java/com/coronaide/test/lockdown/cli/KeyGenerationTest.java
+++ b/lockdown-cli/src/test/java/com/coronaide/test/lockdown/cli/KeyGenerationTest.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 28, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.test.lockdown.cli;
 

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/CredentialStore.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/CredentialStore.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 25, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown;
 

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/KeyGenerator.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/KeyGenerator.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 24, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown;
 

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/model/KeyFiles.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/model/KeyFiles.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 24, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.lockdown.model;
 

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/model/package-info.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/model/package-info.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
+ *
+ * This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.
+ */
 /**
  * Contains data representations used for input and output in APIs
  *

--- a/lockdown-core/src/main/java/com/coronaide/lockdown/package-info.java
+++ b/lockdown-core/src/main/java/com/coronaide/lockdown/package-info.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
+ *
+ * This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.
+ */
 /**
  * Central classes for operations provided by the library
  *

--- a/lockdown-core/src/test/java/com/coronaide/test/lockdown/CredentialStoreTest.java
+++ b/lockdown-core/src/test/java/com/coronaide/test/lockdown/CredentialStoreTest.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 26, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.test.lockdown;
 

--- a/lockdown-core/src/test/java/com/coronaide/test/lockdown/KeyGeneratorTest.java
+++ b/lockdown-core/src/test/java/com/coronaide/test/lockdown/KeyGeneratorTest.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 25, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.test.lockdown;
 

--- a/lockdown-core/src/test/java/com/coronaide/test/lockdown/model/KeyFilesTest.java
+++ b/lockdown-core/src/test/java/com/coronaide/test/lockdown/model/KeyFilesTest.java
@@ -1,12 +1,8 @@
 /*
- * Copyright (c) Apr 25, 2017 Corona IDE.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
  *
- * Contributors:
- *    romeara - initial API and implementation and/or initial documentation
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
  */
 package com.coronaide.test.lockdown.model;
 

--- a/lockdown-gradle-plugin/src/main/groovy/com/coronaide/lockdown/gradle/task/AddCredentialsTask.groovy
+++ b/lockdown-gradle-plugin/src/main/groovy/com/coronaide/lockdown/gradle/task/AddCredentialsTask.groovy
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2017 The Corona-IDE@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
 package com.coronaide.lockdown.gradle.task
 
 import org.gradle.api.GradleException


### PR DESCRIPTION
Complete the switch to the MIT license, updating headers, legal
documentation, and including the license in JAR archives