### PR TITLE
Fix documented group ID

### DIFF
--- a/lockdown-gradle-plugin/README.md
+++ b/lockdown-gradle-plugin/README.md
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath group: 'org.starchart.lockdown', name: 'lockdown-gradle-plugin', version: '2.0.0'
+        classpath group: 'org.starchartlabs.lockdown', name: 'lockdown-gradle-plugin', version: '2.0.0'
     }
 }
 


### PR DESCRIPTION
Correct the group ID in the example application of the plug-in from "org.starchart.lockdown" to "org.starchartlabs.lockdown"