### PR TITLE
Update to new SonarQube Cloud URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sonarqube {
         property 'sonar.junit.reportsPath', file("${buildDir}/test-results/test")
         property 'sonar.core.codeCoveragePlugin', 'jacoco'
         property 'sonar.jacoco.reportPaths', "${buildDir}/jacoco/test.exec"
-        property 'sonar.host.url', 'https://sonarqube.com'
+        property 'sonar.host.url', 'https://sonarcloud.io'
     }
 }
 


### PR DESCRIPTION
I recently got an e-mail that the old host URL is deprecated in favor of this new naming. Update so it don't be breaking